### PR TITLE
fix: timePicker not showing now the seconds as intended

### DIFF
--- a/bugalink-frontend/components/pages/routines/common/index.tsx
+++ b/bugalink-frontend/components/pages/routines/common/index.tsx
@@ -253,8 +253,8 @@ export default function NewRoutine({
       lat: routine.destination.latitude,
       lng: routine.destination.longitude,
     });
-    setPickTimeFrom(routine.departure_time_start);
-    setPickTimeTo(routine.departure_time_end);
+    setPickTimeFrom(routine.departure_time_start.length > 5 ? routine.departure_time_start.substring(0, 5) : routine.departure_time_start);
+    setPickTimeTo(routine.departure_time_end.length > 5 ? routine.departure_time_end.substring(0, 5) : routine.departure_time_end);
     setSelectedDays([routine.day_of_week]);
 
     if (routineDetailsDriver) {


### PR DESCRIPTION
Quickfix on timePicker showing seconds when they are not relevant.
I thought the change was intended but wasn't as @Icaro212 told me after I accepted the pull request.

Sorry for the inconvecience.