### PR TITLE
fix: reinit carousel scroll on SWR update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarCloud Scan (Backend)

--- a/bugalink-frontend/components/carousel.tsx
+++ b/bugalink-frontend/components/carousel.tsx
@@ -46,14 +46,20 @@ export default function UpcomingTripsCarousel(props) {
   }, [emblaApi, setTweenValues]);
 
   useEffect(() => {
+    // Everytime upcomingTrips changes, we need to reinitialize the carousel
+    // so it can recalculate the number of slides and the scroll snap list
+    emblaApi?.reInit();
+  }, [upcomingTrips]);
+
+  useEffect(() => {
     if (!emblaApi || !upcomingTrips) return;
 
     onScroll();
     emblaApi.on('scroll', () => {
-      flushSync(() => onScroll());
+      flushSync(onScroll);
     });
     emblaApi.on('reInit', onScroll);
-  }, [emblaApi, onScroll, upcomingTrips]);
+  }, [emblaApi, onScroll]);
 
   // They are used for both skeleton and real cards so we can extract them to a variable here
   // cn is a library that allows you to conditionally concat classNames safely (avoid undefined, etc.)


### PR DESCRIPTION
The carousel now re-initializes every time there is a change in the upcoming trips list (for example, if someone rejects your trip request and it stops appearing in your upcoming trips). This fixes a bug where the carousel still acted like there were the old number of items, allowing you to scroll out of boundaries.

A way to test this is by changing the request status of a trip request that you have such that it disappears from your upcomingTrips list (for example, changing a `PENDING` request that appears in my list to `REJECTED`), then clicking on the screen for SWR to re-fetch it. It should update the list on the view and scrolling should work as expected 👍 

![image](https://user-images.githubusercontent.com/53608787/233945667-9f9d0c54-e527-465d-b673-5709611a5dc3.png)
