### PR TITLE
fix: usePassenger in trip requests

### DIFF
--- a/bugalink-backend/passengers/serializers.py
+++ b/bugalink-backend/passengers/serializers.py
@@ -13,7 +13,7 @@ class PassengerSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Passenger
-        fields = ("id", "routines", "trips")
+        fields = ("id", "user", "routines", "trips")
 
     def get_routines(self, obj) -> PassengerRoutineSerializer(many=True):
         routines = obj.routines.all()

--- a/bugalink-frontend/components/cards/request/index.tsx
+++ b/bugalink-frontend/components/cards/request/index.tsx
@@ -4,6 +4,7 @@ import useUser from '@/hooks/useUser';
 import TripRequestI from '@/interfaces/tripRequest';
 import { shortenName } from '@/utils/formatters';
 import TripCard from '../recommendation';
+import usePassenger from '@/hooks/usePassenger';
 
 type Props = {
   request: TripRequestI;
@@ -11,14 +12,16 @@ type Props = {
 };
 
 export default function RequestCard({ request, className = '' }: Props) {
-  const { user, isLoading, isError } = useUser(request.passenger);
+  const { passenger, isLoading, isError } = usePassenger(request.passenger);
   // NOTE: this works now because passengers and drivers have the same ID.
   // If we were to use different IDs for them (for example UUIDs), we would
   // need to use a different hook here.
 
-  if (!user || isLoading || isError) {
+  if (!passenger || isLoading || isError) {
     return <RequestCardSkeleton />;
   }
+
+  const { user } = useUser(passenger.user);
 
   return (
     <div className={'flex w-full flex-col bg-white ' + className}>

--- a/bugalink-frontend/interfaces/passenger.ts
+++ b/bugalink-frontend/interfaces/passenger.ts
@@ -3,7 +3,7 @@ import PassengerRoutineI from './passengerRoutine';
 
 type PassengerI = {
   id: number;
-  user: UserI;
+  user: number | UserI;
   routines: PassengerRoutineI[];
 };
 

--- a/bugalink-frontend/pages/users/[id]/edit.tsx
+++ b/bugalink-frontend/pages/users/[id]/edit.tsx
@@ -8,7 +8,6 @@ import NEXT_ROUTES from '@/constants/nextRoutes';
 import useUser from '@/hooks/useUser';
 import UserI from '@/interfaces/user';
 import { axiosAuth } from '@/lib/axios';
-import { set } from 'cypress/types/lodash';
 import { GetServerSideProps } from 'next';
 import { signOut } from 'next-auth/react';
 import Pencil from 'public/assets/edit.svg';


### PR DESCRIPTION
When there is a superuser created, the ids of passenger and user do not match and in the trip requests view useUser is called with the id of a passenger. We have added in backend the attribute "user" to be able to get from usePassenger the id of the associated user and from there to be able to call the desired useUser. 
This problem does not occur in other sites